### PR TITLE
Migrate login screen to BLoC state management

### DIFF
--- a/lib/logic/blocs/login/login_state.dart
+++ b/lib/logic/blocs/login/login_state.dart
@@ -34,6 +34,7 @@ class LoginFormState extends LoginState {
   final String? emailError;
   final String? passwordError;
   final bool isFormValid;
+  final bool obscurePassword;
 
   const LoginFormState({
     this.email = '',
@@ -41,6 +42,7 @@ class LoginFormState extends LoginState {
     this.emailError,
     this.passwordError,
     this.isFormValid = false,
+    this.obscurePassword = true,
   });
 
   LoginFormState copyWith({
@@ -49,6 +51,7 @@ class LoginFormState extends LoginState {
     String? emailError,
     String? passwordError,
     bool? isFormValid,
+    bool? obscurePassword,
   }) {
     return LoginFormState(
       email: email ?? this.email,
@@ -56,15 +59,17 @@ class LoginFormState extends LoginState {
       emailError: emailError ?? this.emailError,
       passwordError: passwordError ?? this.passwordError,
       isFormValid: isFormValid ?? this.isFormValid,
+      obscurePassword: obscurePassword ?? this.obscurePassword,
     );
   }
 
   @override
   List<Object?> get props => [
-    email,
-    password,
-    emailError,
-    passwordError,
-    isFormValid,
-  ];
+        email,
+        password,
+        emailError,
+        passwordError,
+        isFormValid,
+        obscurePassword,
+      ];
 }

--- a/lib/presentation/widgets/auth/login/email_field.dart
+++ b/lib/presentation/widgets/auth/login/email_field.dart
@@ -13,6 +13,13 @@ class EmailField extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<LoginBloc, LoginState>(
+      buildWhen: (previous, current) {
+        if (previous is LoginFormState && current is LoginFormState) {
+          return previous.email != current.email ||
+              previous.emailError != current.emailError;
+        }
+        return previous.runtimeType != current.runtimeType;
+      },
       builder: (context, state) {
         String email = '';
         String? emailError;

--- a/lib/presentation/widgets/auth/login/login_button.dart
+++ b/lib/presentation/widgets/auth/login/login_button.dart
@@ -13,6 +13,12 @@ class LoginButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<LoginBloc, LoginState>(
+      buildWhen: (previous, current) {
+        if (previous is LoginFormState && current is LoginFormState) {
+          return previous.isFormValid != current.isFormValid;
+        }
+        return previous.runtimeType != current.runtimeType;
+      },
       builder: (context, state) {
         final isLoading = state is LoginLoading;
         final isFormValid = state is LoginFormState && state.isFormValid;

--- a/lib/presentation/widgets/auth/login/password_field.dart
+++ b/lib/presentation/widgets/auth/login/password_field.dart
@@ -7,26 +7,29 @@ import '../../../../logic/blocs/login/login_bloc.dart';
 import '../../../../logic/blocs/login/login_event.dart';
 import '../../../../logic/blocs/login/login_state.dart';
 
-class PasswordField extends StatefulWidget {
+class PasswordField extends StatelessWidget {
   const PasswordField({super.key});
-
-  @override
-  State<PasswordField> createState() => _PasswordFieldState();
-}
-
-class _PasswordFieldState extends State<PasswordField> {
-  bool _obscurePassword = true;
 
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<LoginBloc, LoginState>(
+      buildWhen: (previous, current) {
+        if (previous is LoginFormState && current is LoginFormState) {
+          return previous.password != current.password ||
+              previous.passwordError != current.passwordError ||
+              previous.obscurePassword != current.obscurePassword;
+        }
+        return previous.runtimeType != current.runtimeType;
+      },
       builder: (context, state) {
         String password = '';
         String? passwordError;
-        
+        bool obscure = true;
+
         if (state is LoginFormState) {
           password = state.password;
           passwordError = state.passwordError;
+          obscure = state.obscurePassword;
         }
 
         return Column(
@@ -59,7 +62,7 @@ class _PasswordFieldState extends State<PasswordField> {
                 onChanged: (value) {
                   context.read<LoginBloc>().add(LoginPasswordChanged(value));
                 },
-                obscureText: _obscurePassword,
+                obscureText: obscure,
                 style: GoogleFonts.nunitoSans(
                   fontSize: 16.sp,
                   color: const Color(0xFF1A1A1A),
@@ -77,14 +80,14 @@ class _PasswordFieldState extends State<PasswordField> {
                   ),
                   suffixIcon: IconButton(
                     icon: Icon(
-                      _obscurePassword ? Icons.visibility_off : Icons.visibility,
+                      obscure ? Icons.visibility_off : Icons.visibility,
                       color: const Color(0xFF9CA3AF),
                       size: 20.sp,
                     ),
                     onPressed: () {
-                      setState(() {
-                        _obscurePassword = !_obscurePassword;
-                      });
+                      context
+                          .read<LoginBloc>()
+                          .add(const LoginPasswordVisibilityToggled());
                     },
                   ),
                   border: InputBorder.none,


### PR DESCRIPTION
Completes BLoC migration for the login screen, centralizing password visibility state and optimizing UI rebuilds.

This PR finalizes the BLoC refactor by moving password visibility state into the BLoC, converting `PasswordField` to a `StatelessWidget`, and adding `buildWhen` clauses to `EmailField`, `PasswordField`, and `LoginButton` to reduce unnecessary UI rebuilds. It also improves UX by restoring the form state after a login failure, allowing users to correct their input.

---
<a href="https://cursor.com/background-agent?bcId=bc-132bb01e-5fed-44e6-90d8-7214f9bf223f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-132bb01e-5fed-44e6-90d8-7214f9bf223f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

